### PR TITLE
Add prototype UI to main page

### DIFF
--- a/covidmap/src/main/webapp/index.html
+++ b/covidmap/src/main/webapp/index.html
@@ -2,16 +2,24 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>Team 31 Site</title>
+    <title>covidmap</title>
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
+
   <body>
-    <div id="content">
-      <h1>Team 31 Site</h1>
-      <p>Click here to get a random message:</p>
-      <button onclick="addRandomGreeting()">Hello</button>
-      <div id="greeting-container"></div>
+    <div id="title">
+        <p>COVIDMAP</p>
     </div>
+
+    <div id="info"></div>
+
+    <div id="shared">
+        <div id="map"></div>
+    </div>
+
+    <div class="footer">
+        <p>Footer/Contact</p>
+    </div> 
   </body>
 </html>

--- a/covidmap/src/main/webapp/style.css
+++ b/covidmap/src/main/webapp/style.css
@@ -1,9 +1,58 @@
-#content {
-  margin-left: auto;
-  margin-right: auto;
-  width: 650px;
+#title {
+    margin-left: auto;
+    margin-right: auto;
+    width: 369px;
+    height: 75px;
+    left: 535px;
+    top: 53px;
+
+    font-family: Roboto;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 64px;
+    line-height: 75px;
+    /* identical to box height */
+
+    letter-spacing: 0.1em;
+
+    color: #000000;
 }
 
-#greeting-container {
-  margin-top: 20px;
+.footer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background-color: #C4C4C4;
+    color: black;
+    text-align: center;
+}
+
+#map {
+    position: absolute;
+    width: 871px;
+    height: 498px;
+    top: 263px;
+
+    background: #C4C4C4;
+    border-radius: 17px;
+}
+
+#info {
+    margin-left: auto;
+    margin-right: auto;
+    width: 1373px;
+    height: 74px;
+    left: 33px;
+    top: 153px;
+
+    background: #C4C4C4;
+    border-radius: 17px;
+}
+
+#shared {
+    margin-left: auto;
+    margin-right: auto;
+    width: 1373px;
+    height: 498px;
 }


### PR DESCRIPTION
Added a quick prototype UI to the application. The grey division on the left is intended for the map element, and the white space to the right for any other features/map info we want to put.