### PR TITLE
Added NYTimes api article search functionality

### DIFF
--- a/covidmap/src/main/webapp/index.html
+++ b/covidmap/src/main/webapp/index.html
@@ -15,11 +15,62 @@
     <div id="info"></div>
 
     <div id="shared">
-        <div id="map"></div>
+        <div id="map">
+            <form class="search" action="">
+                    <label for"">News</label>
+                <input class="input" type="text" />
+                <input type="submit" />
+            </form>
+
+            <div class="container">
+                <ul class="news-list"></ul>
+            </div>
+        </div>
     </div>
 
     <div class="footer">
         <p>Footer/Contact</p>
     </div> 
+
+    <script>
+        const searchFrom = document.querySelector('.search');
+        const input = document.querySelector('.input');
+        const newsList = document.querySelector('.news-list');
+
+        searchFrom.addEventListener('submit', newsFetch)
+
+        function newsFetch(e) {
+            // checks if search field is empty
+            if (input.value == '') {
+                alert('Please enter search!')
+                return
+            }
+            
+            e.preventDefault()
+
+            const apiKey = 'nalhGwkCIzLTssWOSn8LbXWKZ4AhIHCW' // API KEY for NYTimes api
+            let topic = input.value;
+
+            let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&api-key=${apiKey}` // api query, to be expanded/modified
+
+            // iterates through JSON returned by api and creates list elements for page
+            fetch(url).then((res)=>{
+                return res.json()
+            }).then((data)=>{
+                newsList.innerHTML = ''
+                for (var i = 0; i < 10; i++) {
+                    let li = document.createElement('li');
+                    let a = document.createElement('a');
+                    a.setAttribute('href', data.response.docs[i].web_url); // attaches url/link to list element
+                    a.setAttribute('target', '_blank');
+                    a.textContent = data.response.docs[i].headline.main; // sets list element name/title
+                    li.appendChild(a);
+                    newsList.appendChild(li); // final element created
+                }
+            }).catch((error)=>{
+                console.log(error)
+            })
+        }
+    </script>
   </body>
 </html>

--- a/covidmap/src/main/webapp/style.css
+++ b/covidmap/src/main/webapp/style.css
@@ -56,3 +56,14 @@
     width: 1373px;
     height: 498px;
 }
+
+.search {
+    position: absolute;
+    top: 10px;
+    margin-left: 15px;
+}
+
+.container {
+    position: absolute;
+    top: 5%;
+}


### PR DESCRIPTION
Implemented basic news search functionality using NYTimes article api based on keyword(s). In the future this is intended to return article headlines on COVID-19 based on location. Currently implemented in index.html with <script> tags. Displayed in map division as a placeholder.

Issue: Speed could be improved (It is currently OK, but could be better).

![basic](https://user-images.githubusercontent.com/8602549/86425219-65abd680-bc99-11ea-9d78-5158ac5efb96.JPG)
