### PR TITLE
Modify api query to return results based on location

### DIFF
--- a/covidmap/src/main/webapp/index.html
+++ b/covidmap/src/main/webapp/index.html
@@ -51,7 +51,7 @@
             const apiKey = 'nalhGwkCIzLTssWOSn8LbXWKZ4AhIHCW' // API KEY for NYTimes api
             let topic = input.value;
 
-            let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&api-key=${apiKey}` // api query, to be expanded/modified
+            let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&fq=covid&sort=newest&api-key=${apiKey}` // api query
 
             // iterates through JSON returned by api and creates list elements for page
             fetch(url).then((res)=>{


### PR DESCRIPTION
Modified the API query to return results based on location. Variable "topic" sets location to search, to be connected to map ping. sorts articles by newest-old.

![api](https://user-images.githubusercontent.com/8602549/86524224-b1db5000-be2c-11ea-9942-4503fc4d9809.JPG)
