### PR TITLE
Changes to api key method

### DIFF
--- a/covidmap/src/main/java/com/google/sps/servlets/NewsServlet.java
+++ b/covidmap/src/main/java/com/google/sps/servlets/NewsServlet.java
@@ -1,0 +1,34 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/news")
+public final class NewsServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+    String key = "nalhGwkCIzLTssWOSn8LbXWKZ4AhIHCW";
+
+    response.setContentType("text/html;");
+    response.getWriter().println(key);
+  }
+}

--- a/covidmap/src/main/java/com/google/sps/servlets/NewsServlet.java
+++ b/covidmap/src/main/java/com/google/sps/servlets/NewsServlet.java
@@ -14,21 +14,40 @@
 
 package com.google.sps.servlets;
 
+import java.util.ArrayList;
+import java.util.List;
+import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 
 @WebServlet("/news")
 public final class NewsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query("apiKeys");
 
-    String key = "nalhGwkCIzLTssWOSn8LbXWKZ4AhIHCW";
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
 
-    response.setContentType("text/html;");
-    response.getWriter().println(key);
+    List<String> keys = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      String key = (String) entity.getProperty("key");
+      keys.add(key);
+    }
+
+    Gson gson = new Gson();
+    
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(keys));
   }
 }

--- a/covidmap/src/main/webapp/script.js
+++ b/covidmap/src/main/webapp/script.js
@@ -5,16 +5,20 @@ function getNews() {
 
     searchFrom.addEventListener('submit', newsFetch)
 
-    function newsFetch(e) {
+    async function newsFetch(e) {
         // checks if search field is empty
         if (input.value == '') {
             alert('Please enter search!')
             return
         }
-                
+                    
+        newsList.innerHTML = ''
+
         e.preventDefault()
 
-        const apiKey = 'nalhGwkCIzLTssWOSn8LbXWKZ4AhIHCW' // API KEY for NYTimes api
+        const response = await fetch('/news');
+        const apiKey = await response.text();
+
         let topic = input.value;
 
         let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&fq=covid&sort=newest&api-key=${apiKey}` // api query
@@ -23,7 +27,23 @@ function getNews() {
         fetch(url).then((res)=>{
             return res.json()
         }).then((data)=>{
-            newsList.innerHTML = ''
+            data.response.docs.forEach(article =>{
+                let li = document.createElement('li');
+                let a = document.createElement('a');
+                a.setAttribute('href', article.web_url); // attaches url/link to list element
+                a.setAttribute('target', '_blank');
+                a.textContent = article.headline.main; // sets list element name/title
+                li.appendChild(a);
+                newsList.appendChild(li); // final element created
+            })
+        }).catch((error)=>{
+            console.log(error)
+        })
+    }
+}
+
+
+/*
             for (var i = 0; i < 10; i++) {
                 let li = document.createElement('li');
                 let a = document.createElement('a');
@@ -33,8 +53,4 @@ function getNews() {
                 li.appendChild(a);
                 newsList.appendChild(li); // final element created
             }
-        }).catch((error)=>{
-            console.log(error)
-        })
-    }
-}
+*/

--- a/covidmap/src/main/webapp/script.js
+++ b/covidmap/src/main/webapp/script.js
@@ -19,7 +19,7 @@ function getNews() {
             e.preventDefault()
 
             const response = await fetch('/news');
-            const apiKey = await response.text();
+            const apiKey = await response.json();
 
             let topic = input.value;
 

--- a/covidmap/src/main/webapp/script.js
+++ b/covidmap/src/main/webapp/script.js
@@ -2,55 +2,46 @@ function getNews() {
     const searchFrom = document.querySelector('.search');
     const input = document.querySelector('.input');
     const newsList = document.querySelector('.news-list');
+    var flag = 0;
 
     searchFrom.addEventListener('submit', newsFetch)
 
     async function newsFetch(e) {
         // checks if search field is empty
-        if (input.value == '') {
+        if (input.value == '' && flag == 0) {
             alert('Please enter search!')
             return
         }
-                    
-        newsList.innerHTML = ''
 
-        e.preventDefault()
+        if (flag == 0) {            
+            newsList.innerHTML = ''
 
-        const response = await fetch('/news');
-        const apiKey = await response.text();
+            e.preventDefault()
 
-        let topic = input.value;
+            const response = await fetch('/news');
+            const apiKey = await response.text();
 
-        let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&fq=covid&sort=newest&api-key=${apiKey}` // api query
+            let topic = input.value;
 
-        // iterates through JSON returned by api and creates list elements for page
-        fetch(url).then((res)=>{
-            return res.json()
-        }).then((data)=>{
-            data.response.docs.forEach(article =>{
-                let li = document.createElement('li');
-                let a = document.createElement('a');
-                a.setAttribute('href', article.web_url); // attaches url/link to list element
-                a.setAttribute('target', '_blank');
-                a.textContent = article.headline.main; // sets list element name/title
-                li.appendChild(a);
-                newsList.appendChild(li); // final element created
+            let url = `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${topic}&fq=covid&sort=newest&api-key=${apiKey}` // api query
+
+            // iterates through JSON returned by api and creates list elements for page
+            fetch(url).then((res)=>{
+                return res.json()
+            }).then((data)=>{
+                data.response.docs.forEach(article =>{
+                    let li = document.createElement('li');
+                    let a = document.createElement('a');
+                    a.setAttribute('href', article.web_url); // attaches url/link to list element
+                    a.setAttribute('target', '_blank');
+                    a.textContent = article.headline.main; // sets list element name/title
+                    li.appendChild(a);
+                    newsList.appendChild(li); // final element created
+                })
+            }).catch((error)=>{
+                console.log(error)
             })
-        }).catch((error)=>{
-            console.log(error)
-        })
+            flag = 1;
+        }
     }
 }
-
-
-/*
-            for (var i = 0; i < 10; i++) {
-                let li = document.createElement('li');
-                let a = document.createElement('a');
-                a.setAttribute('href', data.response.docs[i].web_url); // attaches url/link to list element
-                a.setAttribute('target', '_blank');
-                a.textContent = data.response.docs[i].headline.main; // sets list element name/title
-                li.appendChild(a);
-                newsList.appendChild(li); // final element created
-            }
-*/


### PR DESCRIPTION
Moved api key to NewsServlet.java in preparation for potential storage of key on server. Also modified method of list creation for the news list (Now uses forEach() method instead of for loop). 

ISSUE: In making these changes, I came across an issue where when you search for news, the results get shown multiple times based on the number of previous news searches(i.e. If I had searched for New York and Los Angeles news prior to Denver, the results for Denver would show 3 times).

TL;DR: News api method cleaned up, significant bug made apparent as a result. Preparations made for more secure api key storage.

![NewsBug](https://user-images.githubusercontent.com/8602549/86988502-355ab100-c14d-11ea-9c44-e32ab0992040.JPG)
